### PR TITLE
Add cc:license statements to document as per Wikipedia/dbpedia licensing...

### DIFF
--- a/lib/thing.rb
+++ b/lib/thing.rb
@@ -122,6 +122,10 @@ class Thing < BaseModel
 
   WIKIBASE = RDF::Vocabulary.new('http://www.wikidata.org/ontology#')
   SCHEMA = RDF::Vocabulary.new('http://schema.org/')
+  CC = RDF::Vocabulary.new('http://creativecommons.org/ns#')
+
+  CC_BY_SA_30 = RDF::URI("http://creativecommons.org/licenses/by-sa/3.0/")
+  GNU_FDL_13 = RDF::URI("http://gnu.org/licenses/fdl-1.3.html")
 
   def to_rdf
     RDF::Graph.new do |graph|
@@ -130,6 +134,8 @@ class Thing < BaseModel
       graph << [doc_uri, RDF::DC.title, "dbpedia lite thing - #{label}"]
       graph << [doc_uri, RDF::DC.modified, updated_at] unless updated_at.nil?
       graph << [doc_uri, RDF::FOAF.primaryTopic, self.uri]
+      graph << [doc_uri, CC.license, CC_BY_SA_30]
+      graph << [doc_uri, CC.license, GNU_FDL_13]
 
       # Triples about the Thing
       graph << [self.uri, RDF.type, RDF::OWL.Thing]

--- a/spec/thing_spec.rb
+++ b/spec/thing_spec.rb
@@ -274,8 +274,8 @@ describe Thing do
       @graph.class.should == RDF::Graph
     end
 
-    it "should return a graph with 15 triples" do
-      @graph.count.should == 20
+    it "should return a graph with 22 triples" do
+      @graph.count.should == 22
     end
 
     it "should include an rdf:type triple for the thing" do
@@ -373,6 +373,23 @@ describe Thing do
         RDF::Literal(DateTime.parse('2010-05-08T17:20:04Z'))
       ])
     end
+
+    it "should include a cc:license, CC-BY-SA 3.0, triple for the document" do
+      @graph.should have_triple([
+        RDF::URI("http://www.dbpedialite.org/things/52780"),
+        RDF::URI("http://creativecommons.org/ns#license"),
+        RDF::URI("http://creativecommons.org/licenses/by-sa/3.0/")
+      ])
+    end
+
+    it "should include a cc:license, GNU FDL 1.3, triple for the document" do
+      @graph.should have_triple([
+        RDF::URI("http://www.dbpedialite.org/things/52780"),
+        RDF::URI("http://creativecommons.org/ns#license"),
+        RDF::URI("http://gnu.org/licenses/fdl-1.3.html")
+      ])
+    end
+
 
   end
 end


### PR DESCRIPTION
In keeping with the standard practice of declaring copyright and licensing terms in the footer of every web page (since a client can land anywhere), Linked Open Data should declare the licensing terms of the data on each foaf:Document along with the rest of the metadata about that page.  Geonames is a good example of this.

This patch copies in the dual licenses declared by Wikipedia (and dbpedia), CC BY-SA 3.0 and GFDL 1.3.
