### PR TITLE
Update dbpedia uri-encoding unsafe characters.

### DIFF
--- a/lib/wikipedia_api.rb
+++ b/lib/wikipedia_api.rb
@@ -4,7 +4,7 @@ class WikipediaApi < MediaWikiApi
 
   ABSTRACT_MAX_LENGTH = 500
   ABSTRACT_TRUNCATE_LENGTH = 700
-  DBPEDIA_UNSAFE_REGEXP = Regexp.new('[^a-zA-Z0-9\.\-*/:_,&]', false, 'N').freeze
+  DBPEDIA_UNSAFE_REGEXP = Regexp.new('[^!\$&\'\(\)*\+,\-\./0-9:;=@A-Z_a-z~]', false, 'N').freeze
 
   class Redirect < MediaWikiApi::Exception
     attr_reader :pageid
@@ -21,7 +21,7 @@ class WikipediaApi < MediaWikiApi
   end
 
   def self.title_to_dbpedia_key(title)
-    # From http://dbpedia.org/URIencoding
+    # From http://dbpedia.org/uri-encoding
     URI::escape(title.gsub(' ', '_').squeeze('_'), DBPEDIA_UNSAFE_REGEXP)
   end
 

--- a/spec/base_model_spec.rb
+++ b/spec/base_model_spec.rb
@@ -74,7 +74,7 @@ describe BaseModel do
     end
 
     it "should respond to 'dbpedia_uri' with the dbpedia URI" do
-      @obj.dbpedia_uri.should == RDF::URI('http://dbpedia.org/resource/Keith_Allen_%28actor%29')
+      @obj.dbpedia_uri.should == RDF::URI('http://dbpedia.org/resource/Keith_Allen_(actor)')
     end
   end
 

--- a/spec/wikipedia_api_spec.rb
+++ b/spec/wikipedia_api_spec.rb
@@ -5,7 +5,7 @@ require 'wikipedia_api'
 describe WikipediaApi do
   context "escaping a page title to a DBpedia key" do
     it "should apply the encoding rules from dbpedia.org" do
-      WikipediaApi.title_to_dbpedia_key('Mozambique (Portugal)').should == 'Mozambique_%28Portugal%29'
+      WikipediaApi.title_to_dbpedia_key('Mozambique (Portugal)').should == 'Mozambique_(Portugal)'
       WikipediaApi.title_to_dbpedia_key('S/2012_P_1').should == 'S/2012_P_1'
     end
   end


### PR DESCRIPTION
Hi Nick,

We're having issues with the encoding of dbpedia URIs, as I think dbpedia changed their encoding rules between 3.7 and 3.8.  I've gone through the table at the bottom of http://dbpedia.org/uri-encoding and updated the Regex for non-safe characters, as well as updated a couple of tests.

Could you take a look at this PR and let us know if you'll be able to merge and push the fix live?

Cheers,
Alex.